### PR TITLE
support queries without arguments

### DIFF
--- a/zqlite.zig
+++ b/zqlite.zig
@@ -99,10 +99,8 @@ pub const Conn = struct {
 		}
 
 		const stmt = n_stmt.?;
-		if (values.len > 0) {
-			inline for (values, 0..) |value, i| {
-				try bindValue(@TypeOf(value), stmt, value, i + 1);
-			}
+		inline for (values, 0..) |value, i| {
+			try bindValue(@TypeOf(value), stmt, value, i + 1);
 		}
 
 		return .{


### PR DESCRIPTION
~~Remove unnecessary check that breaks compilation on empty tuples.~~

Nevermind, this was a bug in my own code.