### PR TITLE
Add include path on zqlite module rather than exe in build.zig

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ const zqlite = b.dependency("zqlite", .{
     .target = target,
     .optimize = optimize,
 });
+zqlite.module("zqlite").addIncludePath(b.path("lib/sqlite3/"));
 exe.addCSourceFile(.{
     .file = b.path("lib/sqlite3/sqlite3.c"),
     .flags = &[_][]const u8{
@@ -86,7 +87,6 @@ exe.addCSourceFile(.{
         "-DHAVE_USLEEP=0",
     },
 });
-exe.addIncludePath(b.path("lib/sqlite3/"));
 exe.root_module.addImport("zqlite", zqlite.module("zqlite"));
 ```
 


### PR DESCRIPTION
I'm working with Zig 0.13.0 and I've needed to make the change to mybuild.zig reflected in the PR's diff. Hopefully this may save other some debugging time.

Awesome project and equally awesome Dune reference in the README btw. :)