### PR TITLE
Update for zig 0.14-latest

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -17,7 +17,7 @@ pub fn build(b: *std.Build) !void {
     const lib_test = b.addTest(.{
         .target = target,
         .optimize = optimize,
-        .test_runner = b.path("test_runner.zig"),
+        .test_runner = .{ .path = b.path("test_runner.zig"), .mode = .simple },
         .root_source_file = b.path("src/zqlite.zig"),
     });
     lib_test.addCSourceFile(.{


### PR DESCRIPTION
In case someone finds this useful, it allows building against latest zig 0.14.0-dev.2866+0d6b17b6a.