### PR TITLE
rename builtin pointer size enum to lowercase

### DIFF
--- a/src/conn.zig
+++ b/src/conn.zig
@@ -283,7 +283,7 @@ pub const Stmt = struct {
             },
             .pointer => |ptr| {
                 switch (ptr.size) {
-                    .One => switch (@typeInfo(ptr.child)) {
+                    .one => switch (@typeInfo(ptr.child)) {
                         .array => |arr| {
                             if (arr.child == u8) {
                                 rc = c.sqlite3_bind_text(stmt, bind_index, value.ptr, @intCast(value.len), c.SQLITE_STATIC);
@@ -293,7 +293,7 @@ pub const Stmt = struct {
                         },
                         else => bindError(T),
                     },
-                    .Slice => switch (ptr.child) {
+                    .slice => switch (ptr.child) {
                         u8 => rc = c.sqlite3_bind_text(stmt, bind_index, value.ptr, @intCast(value.len), c.SQLITE_STATIC),
                         else => bindError(T),
                     },


### PR DESCRIPTION
#14 already has these changes, but introduces additional changes. Based on some previous discussion this project seems to support the latest Zig build, `0.14.0-dev.2851+b074fb7dd`, which does not work with a portion of the changes in #14. Not knowing when the next master build is coming out (possibly as late as Feb 17th as the tagged 0.14.0 build) and in the interest of keeping this library working with the current build, I have separated the working portion of #14 into this PR.

The Zig commit that necessitates this PR: https://github.com/ziglang/zig/commit/af6bad46cd132113e7b8497829a660a79e101742