### PR TITLE
Fix cross compilation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -25,6 +25,7 @@ pub fn build(b: *std.Build) !void {
         }),
     });
     lib.addIncludePath(lib_path);
+    lib.installHeadersDirectory(lib_path, "", .{});
     lib.addCSourceFile(.{
         .file = b.path("lib/sqlite3.c"),
         .flags = sqlite3_build,


### PR DESCRIPTION
Apologies - it seems like my last PR introduced a bug with cross-compilation to Windows.  We need this line as well.

Before this fix (run from a Mac):
```
zig build test -Dtarget=x86_64-windows
test
└─ run test
   └─ compile test Debug x86_64-windows 2 errors
src/zqlite.zig:2:15: error: C import failed
pub const c = @cImport(@cInclude("sqlite3.h"));
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    refAllDecls__anon_438: /Users/g/.zvm/0.15.1/lib/std/testing.zig:1179:14
    test_0: src/zqlite.zig:162:28
.zig-cache/o/b19c4b5839272b01c4241247441eba3a/cimport.h:1:10: error: 'sqlite3.h' file not found
#include <sqlite3.h>
```

After this fix:
```
zig build test -Dtarget=x86_64-windows
test
└─ run test failure
error: the host system (aarch64-macos.15.6.1...15.6.1-none) is unable to execute binaries from the target (x86_64-windows.win10...win11_dt-gnu)
```

It seems like `zig build` is a no-op so that's why I'm using test (which crashes on success once it makes the windows binary and tries to run it on mac).