### PR TITLE
Fix closing uninitialized memory

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -230,14 +230,14 @@ var pool = zqlite.Pool.init(allocator, .{
 
 // Our size is 5, but this will only be executed once, for the first
 // connection in our pool
-fn initializeDB(conn: Conn) !void {
+fn initializeDB(conn: Conn, _: ?*anyopaque) !void {
     try conn.execNoArgs("create table if not exists testing(id int)");
 }
 
 // Our size is 5, so this will be executed 5 times, once for each
 // connection. `initializeDB` is guaranteed to be called before this
 // function is called.
-fn initializeConnection(conn: Conn) !void {
+fn initializeConnection(conn: Conn, _: ?*anyopaque) !void {
     return conn.busyTimeout(1000);
 }
 ```

--- a/src/pool.zig
+++ b/src/pool.zig
@@ -54,6 +54,8 @@ pub const Pool = struct {
             conn._pool = pool;
 
             init_count += 1;
+            conns[i] = conn;
+
             if (i == 0) {
                 if (config.on_first_connection) |f| {
                     try f(conn, config.on_first_connection_context);
@@ -62,7 +64,6 @@ pub const Pool = struct {
             if (on_connection) |f| {
                 try f(conn, config.on_connection_context);
             }
-            conns[i] = conn;
         }
 
         return pool;


### PR DESCRIPTION
`conns[i]` isn't properly initialized if there's an error in either `on_first_connection` or `on_connection`, resulting in closing an invalid Conn memory.

Also update readme example.