### PR TITLE
Add expanded sql method

### DIFF
--- a/src/conn.zig
+++ b/src/conn.zig
@@ -181,6 +181,16 @@ pub const Stmt = struct {
         }
     }
 
+    pub fn expandedSql(self: Stmt, allocator: std.mem.Allocator) ![]u8 {
+        const c_str_opt = c.sqlite3_expanded_sql(self.stmt);
+        const c_str = c_str_opt orelse return error.NoMem;
+        const len = std.mem.len(c_str);
+        const result = try allocator.alloc(u8, len);
+        @memcpy(result, c_str[0..len]);
+        c.sqlite3_free(c_str);
+        return result;
+    }
+
     pub fn boolean(self: Stmt, index: usize) bool {
         return self.int(index) == 1;
     }

--- a/src/conn.zig
+++ b/src/conn.zig
@@ -182,12 +182,11 @@ pub const Stmt = struct {
     }
 
     pub fn expandedSql(self: Stmt, allocator: std.mem.Allocator) ![]u8 {
-        const c_str_opt = c.sqlite3_expanded_sql(self.stmt);
-        const c_str = c_str_opt orelse return error.NoMem;
+        const c_str = c.sqlite3_expanded_sql(self.stmt) orelse return error.NoMem;
+        defer c.sqlite3_free(c_str);
         const len = std.mem.len(c_str);
         const result = try allocator.alloc(u8, len);
         @memcpy(result, c_str[0..len]);
-        c.sqlite3_free(c_str);
         return result;
     }
 


### PR DESCRIPTION
`sqlite3_expanded_sql` allows you to get the full sql statement with bound values interpolated - very helpful for debugging if you want to try running a query directly against a DB.

It returns memory allocated by sqlite that must be freed. Because it is just for debugging, I made the decision to copy this into a slice with a zig allocator and free it immediately.
