### PR TITLE
Return an error when preparing multiple statements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,8 +92,8 @@ The `Conn` type returned by `open` has the following functions:
 
 * `row(sql, args) !?zqlite.Row` - returns an optional row
 * `rows(sql, args) !zqlite.Rows` - returns an iterator that yields rows
-* `exec(sql, args) !void` - executes the statement,
-* `execNoArgs(sql) !void` - micro-optimization if there are no args, `sql` must be a null-terminated string
+* `exec(sql, args) !void` - executes *one* statement,
+* `execNoArgs(sql) !void` - executes one or more statements, `sql` must be a null-terminated string
 * `changes() usize` - the number of rows inserted/updated/deleted by the previous statement
 * `lastInsertedRowId() i64` - the row id of the last inserted row
 * `lastError() [*:0]const u8` - an error string describing the last error

--- a/src/conn.zig
+++ b/src/conn.zig
@@ -63,9 +63,9 @@ pub const Conn = struct {
 
     pub fn prepare(self: Conn, sql: []const u8) !Stmt {
         var n_stmt: ?*c.sqlite3_stmt = null;
-        var pz_tail: [*c]const u8 = 0;
-        const rc = c.sqlite3_prepare_v2(self.conn, sql.ptr, @intCast(sql.len), &n_stmt, &pz_tail);
-        if (pz_tail != 0 and pz_tail.* != 0) {
+        var pz_tail: [*:0]const u8 = undefined;
+        const rc = c.sqlite3_prepare_v2(self.conn, sql.ptr, @intCast(sql.len), &n_stmt, @ptrCast(&pz_tail));
+        if (pz_tail[0] != 0) {
             var trail_stmt: ?*c.sqlite3_stmt = null;
             _ = c.sqlite3_prepare_v2(self.conn, pz_tail, @intCast(sql.len), &trail_stmt, null);
             if (trail_stmt != null) {

--- a/src/conn.zig
+++ b/src/conn.zig
@@ -4,7 +4,6 @@ const c = @cImport(@cInclude("sqlite3.h"));
 const zqlite = @import("zqlite.zig");
 const Blob = zqlite.Blob;
 const Error = zqlite.Error;
-const PrepareError = error{MultipleStatements};
 
 pub const Conn = struct {
     conn: *c.sqlite3,
@@ -69,7 +68,7 @@ pub const Conn = struct {
         if (pz_tail != 0 and pz_tail.* != 0) {
             // SQlite only compiles the first statement it finds,
             // and silently ignores the rest. Make this an error instead.
-            return PrepareError.MultipleStatements;
+            return error.MultipleStatements;
         }
         if (rc != c.SQLITE_OK) {
             return errorFromCode(rc);
@@ -958,7 +957,7 @@ test "preparing multiple statements" {
     defer conn.tryClose() catch unreachable;
 
     try t.expectError(
-        PrepareError.MultipleStatements,
+        error.MultipleStatements,
         conn.exec(
             \\SELECT 1 FROM test;
             \\SELECT 2 FROM test;


### PR DESCRIPTION
`exec()` currently only runs the first statement and silently ignores the rest. This behavior is quite different from `sqlite_exec` where it runs all the statements. To make this more clear, return an error instead when multiple statements are prepared.

This may break any existing code, but that is preferable to silent bugs that goes undetected.

The alternative is to modify exec such that it runs all the statement, but sqlite bind parameters only works per statement, and it would be quite tricky to make this work when one statement doesn't use all the bound parameters.

