### PR TITLE
Updated usage for 0.16.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,21 @@ This library is tested with SQLite3 3.53.0.
 zig fetch --save git+https://github.com/karlseguin/zqlite.zig#master
 ```
 
-2)  The library doesn't attempt to link/include SQLite. You're free to do this how you want.
+2) Link libc in your `build.zig`:
+
+```zig
+const exe = b.addExecutable(.{
+        .name = "example",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+```
+
+3) The library doesn't attempt to link/include SQLite. You're free to do this how you want.
 
 If you have sqlite3 installed on your system you might get away with just adding this to your build.zig
 
@@ -52,20 +66,19 @@ const zqlite = b.dependency("zqlite", .{
     .optimize = optimize,
 });
 
-exe.linkLibC();
-exe.linkSystemLibrary("sqlite3");
+exe.root_module.linkSystemLibrary("sqlite3", .{});
 exe.root_module.addImport("zqlite", zqlite.module("zqlite"));
 ```
 
 Alternatively, If you download the SQLite amalgamation from [the SQLite download page](https://www.sqlite.org/download.html) and place the `sqlite.c` and `sqlite.h` file in your project's `lib/` folder, you can then:
 
-2) Add this in `build.zig`:
+3) Add this in `build.zig`:
 ```zig
 const zqlite = b.dependency("zqlite", .{
     .target = target,
     .optimize = optimize,
 });
-exe.addCSourceFile(.{
+exe.root_module.addCSourceFile(.{
     .file = b.path("lib/sqlite3.c"),
     .flags = &[_][]const u8{
         "-DSQLITE_DQS=0",
@@ -86,7 +99,6 @@ exe.addCSourceFile(.{
         "-DHAVE_USLEEP=0",
     },
 });
-exe.linkLibC();
 exe.root_module.addImport("zqlite", zqlite.module("zqlite"));
 ```
 


### PR DESCRIPTION
Hi, I've changed a couple of things in the readme since the master is now for version 0.16.0.

1) The previous method for linking libc doesn not work anymore, and that is the only one that I've found. 
2) Some functions have been moved to `root_module`, like: [linkSystemLibrary](https://ziglang.org/documentation/master/std/#std.Build.Module.linkSystemLibrary) and [addCSourceFile](https://ziglang.org/documentation/master/std/#std.Build.Module.addCSourceFile).

Let me know if you have some questions,
Thank you!