### PR TITLE
refactor: remove deprecated @cImport

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,16 +9,29 @@ pub fn build(b: *std.Build) !void {
 
     const lib_path = b.path("lib");
 
+    const translate_c = b.addTranslateC(.{
+        .root_source_file = b.path("lib/sqlite3.h"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const mod_zqlite = b.addModule("zqlite", .{
         .root_source_file = b.path("src/zqlite.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{
+                .name = "c",
+                .module = translate_c.createModule(),
+            }
+        },
     });
 
     const mod_sqlite = b.createModule(.{
         .target = target,
         .optimize = optimize,
         .link_libc = true,
+
     });
     mod_sqlite.addIncludePath(lib_path);
     mod_sqlite.addCSourceFile(.{

--- a/src/conn.zig
+++ b/src/conn.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const Io = std.Io;
-const c = @cImport(@cInclude("sqlite3.h"));
+pub const c = @import("c");
 
 const zqlite = @import("zqlite.zig");
 const Blob = zqlite.Blob;

--- a/src/zqlite.zig
+++ b/src/zqlite.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-pub const c = @cImport(@cInclude("sqlite3.h"));
+pub const c = @import("c");
 
 pub const Pool = @import("pool.zig").Pool;
 


### PR DESCRIPTION
Hi there!
This is part of my side-quest of getting [Awebo](https://codeberg.org/awebo-chat/awebo) compiling on Zigs latest main branch again and `@cImport` was already deleted there.