### PR TITLE
Update translate-c dependency to track zig 0.17.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: mlugg/setup-zig@v2
+        with:
+          version: master
       - uses: actions/checkout@v2
       - name: Module test
         run: zig build test

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .translate_c = .{
-            .url = "git+https://codeberg.org/ziglang/translate-c#1b33d1d273f7035a16c45457efdf2afda7cf0925",
-            .hash = "translate_c-0.0.0-Q_BUWrI7BwCBn0jcYDTs1UP047kxSYoFpV6vD6Vuy9Vo",
+            .url = "git+https://codeberg.org/ziglang/translate-c#f94ce1b138c8ad04959de2fea01fc8981cc2ae77",
+            .hash = "translate_c-0.0.0-Q_BUWp84BwD-R_KrWywVjsMETfqkMv4iPdnBUx48FS6y",
         },
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,7 +10,7 @@
     },
     .version = "0.0.1",
     .fingerprint = 0x9fb4d74a63da6245,
-    .minimum_zig_version = "0.16.0",
+    .minimum_zig_version = "0.17.0-dev.1158+1d1193aa7",
     .dependencies = .{
         .translate_c = .{
             .url = "git+https://codeberg.org/ziglang/translate-c#f94ce1b138c8ad04959de2fea01fc8981cc2ae77",


### PR DESCRIPTION
Updating the translate-c dependency for zqlite to work with zig 0.17.x/master projects (like microzig, where this currently breaks it).

See https://codeberg.org/ziglang/translate-c/commit/f94ce1b138c8ad04959de2fea01fc8981cc2ae77